### PR TITLE
feat: workflows: print actor_id for semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,14 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get Semantic Release App Actor ID
+        run: |
+          SEMANTIC_RELEASE_ACTOR_ID=$(gh api "users/semantic-release[bot]" --jq '.id')
+          echo "The actor_id for semantic-release[bot] is: $SEMANTIC_RELEASE_ACTOR_ID"
+          echo "SEMANTIC_RELEASE_ACTOR_ID=$SEMANTIC_RELEASE_ACTOR_ID" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
The actor_id can then be used in bypass rules in repository configuration.