### PR TITLE
fix(ci): make attestation work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,19 @@ jobs:
       enable-mqtt-broker: true
       mqtt-config-path: '.github/mosquitto.conf'
 
+  pre-release-checks:
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/maint/')) && github.ref_type != 'tag' && github.event.head_commit.author.email != 'semantic-release'
+    uses: muxu-io/python-template/.github/workflows/checks.yml@master
+    with:
+      python-versions: '["3.11"]'  # Just one version for speed
+      source-directory: 'src/'
+      enable-mqtt-broker: true
+      mqtt-config-path: '.github/mosquitto.conf'
+      skip-build: true  # Skip build to avoid attestation conflicts
+
   release:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/maint/')) && github.ref_type != 'tag' && github.event.head_commit.author.email != 'semantic-release'
+    needs: [pre-release-checks]
     uses: muxu-io/python-template/.github/workflows/release.yml@master
     secrets:
       SEMANTIC_RELEASE_ADMIN_TOKEN: ${{ secrets.SEMANTIC_RELEASE_ADMIN_TOKEN }}


### PR DESCRIPTION
Some publishers like PyPi need the build to happen on the publishing workflow so they can attestate its origin.