### PR TITLE
fix(ci): make attestation work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,57 @@ jobs:
       enable-mqtt-broker: true
       mqtt-config-path: '.github/mosquitto.conf'
 
-  pre-release-checks:
+  pre-release-test:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/maint/')) && github.ref_type != 'tag' && github.event.head_commit.author.email != 'semantic-release'
-    uses: muxu-io/python-template/.github/workflows/checks.yml@master
-    with:
-      python-versions: '["3.11"]'  # Just one version for speed
-      source-directory: 'src/'
-      enable-mqtt-broker: true
-      mqtt-config-path: '.github/mosquitto.conf'
-      skip-build: true  # Skip build to avoid attestation conflicts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        if: vars.DOCKERHUB_USERNAME
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Start Mosquitto MQTT broker
+        uses: namoshek/mosquitto-github-action@v1
+        with:
+          version: '2.0'
+          ports: '1883:1883'
+          config: ${{ github.workspace }}/.github/mosquitto.conf
+          container-name: 'mosquitto'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Verify MQTT broker
+        run: |
+          echo "Verifying MQTT broker is ready..."
+          timeout 30 bash -c 'until nc -z localhost 1883; do echo "Waiting for MQTT broker..."; sleep 1; done'
+          echo "MQTT broker is accessible on port 1883"
+
+      - name: Run tests
+        run: |
+          echo "Running quick pre-release tests..."
+          timeout 300 pytest -v --tb=short --maxfail=3 -x
+        env:
+          MQTT_BROKER_HOST: localhost
+          MQTT_BROKER_PORT: 1883
+          PYTEST_TIMEOUT: 30
 
   release:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/maint/')) && github.ref_type != 'tag' && github.event.head_commit.author.email != 'semantic-release'
-    needs: [pre-release-checks]
+    needs: [pre-release-test]
     uses: muxu-io/python-template/.github/workflows/release.yml@master
     secrets:
       SEMANTIC_RELEASE_ADMIN_TOKEN: ${{ secrets.SEMANTIC_RELEASE_ADMIN_TOKEN }}


### PR DESCRIPTION
Some publishers like PyPi need the build to happen on the publishing workflow so they can attestate its origin.